### PR TITLE
Hotfix/fix distutils description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-long_description=open('facsimile/description.txt').readline().strip(),
+long_description=open('facsimile/description.txt').readline().strip()
 version = open('facsimile/VERSION').read().strip()
 requirements = open('facsimile/requirements.txt').read().split("\n")
 test_requirements = open('facsimile/requirements-test.txt').read().split("\n")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 long_description=open('facsimile/description.txt').readline().strip()
-version = open('facsimile/VERSION').read().strip()
+version = open('facsimile/VERSION').readline().strip()
 requirements = open('facsimile/requirements.txt').read().split("\n")
 test_requirements = open('facsimile/requirements-test.txt').read().split("\n")
 


### PR DESCRIPTION
The trailing comma caused it to still be a tuple, also changed VERSION parsing to be similar.