### PR TITLE
Add automated PyPI release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,89 @@
+name: Release to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - 'test-release-*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "0.7.17"
+          
+      - name: Install dependencies
+        run: |
+          uv sync --group dev
+          
+      - name: Run tests
+        run: |
+          uv run pytest tests/ --cov=src --cov-report=term-missing -v
+          
+      - name: Run linting
+        run: |
+          uv run pre-commit run --all-files
+          
+      - name: Build package
+        run: |
+          uv build
+          
+      - name: Check build
+        run: |
+          uv run twine check dist/*
+          
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          
+      - name: Determine PyPI repository
+        id: pypi-repo
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "repository=pypi" >> $GITHUB_OUTPUT
+            echo "Publishing to PyPI"
+          elif [[ "${{ github.ref_name }}" == test-release-* ]]; then
+            echo "repository=testpypi" >> $GITHUB_OUTPUT
+            echo "Publishing to TestPyPI"
+          else
+            echo "Not a release ref, skipping"
+            exit 1
+          fi
+          
+      - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://upload.pypi.org/legacy/
+          
+      - name: Publish to TestPyPI
+        if: startsWith(github.ref_name, 'test-release-')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Testing
+- Run tests: `uv run pytest tests/ --cov=src --cov-report=term-missing -v`
+- Run tests with coverage: `uv run pytest tests/ --cov=src --cov-report=xml --cov-report=term-missing -v`
+- Run tests using tox: `tox`
+
+### Linting and Formatting
+- Run pre-commit hooks: `uv run pre-commit run --all-files`
+- Format code: `uv run ruff format`
+- Lint code: `uv run ruff check --fix`
+
+### Dependencies
+- Install dependencies: `uv sync --group dev`
+- Install pre-commit hooks: `uv run pre-commit install --install-hooks`
+
+### Building
+- Build package: `uv build`
+
+## Architecture
+
+### Core Components
+
+**munge** is a data manipulation library and CLI tool that provides codec-based data transformation between different formats (JSON, YAML, TOML, etc.).
+
+#### Key Modules
+
+- **`base.py`**: Contains `CodecBase` metaclass and abstract base class for all codecs. Implements URL opening, loading, and dumping functionality.
+- **`codec/`**: Directory containing format-specific codecs (JSON, YAML, TOML, MySQL). Each codec extends `CodecBase` and registers itself via metaclass.
+- **`config.py`**: Configuration management with `Config` and `MungeConfig` classes. Handles reading/writing config files and URL parsing.
+- **`cli.py`**: Command-line interface implementation using Click. Provides main entry point for data format conversion.
+
+#### Architecture Patterns
+
+1. **Codec Registration**: Codecs self-register via metaclass `Meta` in `base.py:10-30`
+2. **URL-based Data Sources**: Supports file paths, HTTP(S) URLs, and custom schemes via `parse_url()` in `config.py:205-253`
+3. **Plugin System**: Codecs are dynamically loaded and registered in `codec/__init__.py`
+
+#### Data Flow
+
+1. CLI parses input/output arguments
+2. `parse_url()` determines codec from file extension or URL scheme
+3. Source codec loads data using `loadu()` method
+4. Data is transformed/manipulated as needed
+5. Destination codec saves data using `dumpu()` method
+
+The library supports both programmatic use via the `munge` module and command-line usage via the `munge` CLI tool.


### PR DESCRIPTION
- Add GitHub Actions workflow for automated PyPI releases on git tags
- Support TestPyPI releases for branches starting with test-release-
- Uses trusted publishing (OIDC) for secure authentication
- Include comprehensive testing and linting before release